### PR TITLE
Evento: Imersão com Neide Rigo (G014)

### DIFF
--- a/eventos.json
+++ b/eventos.json
@@ -1963,7 +1963,7 @@
     {
       "id": "G014",
       "external_reference": "9299fde5-7407-4cca-8c70-82215b15cf0c",
-      "planilha_url": "https://docs.google.com/spreadsheets/d/1IrTcq80QrC03WfZcZe6VeLgeScjXmrsQcts-vhsjZWw/edit?gid=505962950#gid=505962950",
+      "planilha_url": "https://docs.google.com/spreadsheets/d/1Jl-hpE5_AUrVuoJZySQiR_0ZX97rv6H0uXYH55Q0qN8/edit?gid=505962950#gid=505962950",
       "header": {
         "banner_url": "https://res.cloudinary.com/ddjlqajrd/image/upload/v1757067076/background_1_nuo0n6.jpg",
         "logo_url": "https://res.cloudinary.com/ddjlqajrd/image/upload/v1755164802/logo_serrinha_iiva1a.jpg"

--- a/eventos.json
+++ b/eventos.json
@@ -1959,6 +1959,123 @@
         "evento": []
       },
       "cupons_desconto": []
+    },
+    {
+      "id": "G014",
+      "external_reference": "9299fde5-7407-4cca-8c70-82215b15cf0c",
+      "planilha_url": "https://docs.google.com/spreadsheets/d/1IrTcq80QrC03WfZcZe6VeLgeScjXmrsQcts-vhsjZWw/edit?gid=505962950#gid=505962950",
+      "header": {
+        "banner_url": "https://res.cloudinary.com/ddjlqajrd/image/upload/v1757067076/background_1_nuo0n6.jpg",
+        "logo_url": "https://res.cloudinary.com/ddjlqajrd/image/upload/v1755164802/logo_serrinha_iiva1a.jpg"
+      },
+      "nome": "Imersão com Neide Rigo",
+      "descricao": "Imersão com a nutricionista, cozinheira e escritora Neide Rigo — vivência prática sobre Plantas Alimentícias Não Convencionais (PANC), a biodiversidade dos alimentos brasileiros e a conexão com o ato de plantar, colher e cozinhar.",
+      "politicas_evento_url": "https://drive.google.com/file/d/1IuRoFRJbBzBihsu1XjIf_js9qVExIqLB/view",
+      "observacoes_adicionais": "A imersão acontece de 25 a 27 de setembro de 2026 na Fazenda Serrinha. Os valores são por pessoa e incluem 2 pernoites, 4 refeições por dia, todas as atividades e uso livre de todas as áreas de lazer, com chegada no dia 25 (sexta) à tarde (primeira refeição jantar) e saída no dia 27 (domingo) à tarde (última refeição almoço). Crianças de 5 a 10 anos pagam 50%; menores de 4 anos têm cortesia (1 por quarto). Há 3 vagas de cota social com seleção por carta de interesse.",
+      "tipo_formulario": "hospedagem_apenas",
+      "tipos_acomodacao": [
+        {
+          "id": "indiv",
+          "label": "Quartos privativos para casais, amigos e famílias",
+          "descricao": "Acomodação em quarto privativo, não compartilhado com outras pessoas",
+          "valor_diaria_por_pessoa": 699.5
+        },
+        {
+          "id": "compart",
+          "label": "Alojamento coletivo (até 6 pessoas)",
+          "descricao": "Acomodação compartilhada com outras pessoas",
+          "valor_diaria_por_pessoa": 579
+        },
+        {
+          "id": "sem_pernoite",
+          "label": "Sem pernoite (com almoço e café da tarde)",
+          "descricao": "Participação sem pernoite, com almoço e café da tarde",
+          "valor_diaria_por_pessoa": 441.5
+        }
+      ],
+      "periodos_estadia_opcoes": [
+        {
+          "id": "duas_noites",
+          "label": "2 Noites (25/09 - 27/09)",
+          "data_inicio": "2026-09-25T16:00",
+          "data_fim": "2026-09-27T16:00",
+          "primeira_refeicao": "Jantar",
+          "ultima_refeicao": "Almoço",
+          "num_diarias": 2
+        }
+      ],
+      "valores_evento_opcoes": [],
+      "formas_pagamento_opcoes": [
+        {
+          "id": "cartao_parcelado",
+          "label": "Cartão Parcelado (até 6x sem juros)",
+          "tipo": "cartao_parcelado",
+          "parcelas_maximas": 6,
+          "juros": false,
+          "descricao": "<h4>POLÍTICA DE CONFIRMAÇÃO E CANCELAMENTO</h4><p><b>Confirmação da Reserva:</b></p><p>A reserva somente será confirmada após o recebimento do pagamento.<br>Enquanto o pagamento não for realizado, a hospedagem permanecerá disponível para outros interessados.</p><p><b>Cancelamento:</b></p><p>Até 30 dias antes da data de chegada – reembolso de 100% do valor pago.<br>Até 15 dias antes da data de chegada – reembolso de 50% do valor pago.<br>Menos de 15 dias antes da data de chegada – sem reembolso.</p>",
+          "taxa_gateway_percentual": 0.0
+        },
+        {
+          "id": "cartao_vista",
+          "label": "Cartão Á vista com 4% de desconto",
+          "tipo": "cartao",
+          "parcelas_maximas": 1,
+          "juros": false,
+          "descricao": "<h4>POLÍTICA DE CONFIRMAÇÃO E CANCELAMENTO</h4><p><b>Confirmação da Reserva:</b></p><p>A reserva somente será confirmada após o recebimento do pagamento.<br>Enquanto o pagamento não for realizado, a hospedagem permanecerá disponível para outros interessados.</p><p><b>Cancelamento:</b></p><p>Até 30 dias antes da data de chegada – reembolso de 100% do valor pago.<br>Até 15 dias antes da data de chegada – reembolso de 50% do valor pago.<br>Menos de 15 dias antes da data de chegada – sem reembolso.</p>",
+          "taxa_gateway_percentual": -0.04
+        },
+        {
+          "id": "pix_vista",
+          "label": "PIX à Vista com 8% de desconto",
+          "tipo": "pix",
+          "descricao": "<h4>POLÍTICA DE CONFIRMAÇÃO E CANCELAMENTO</h4><p><b>Confirmação da Reserva:</b></p><p>A reserva somente será confirmada após o recebimento do pagamento.<br>Enquanto o pagamento não for realizado, a hospedagem permanecerá disponível para outros interessados.</p><p><b>Cancelamento:</b></p><p>Até 30 dias antes da data de chegada – reembolso de 100% do valor pago.<br>Até 15 dias antes da data de chegada – reembolso de 50% do valor pago.<br>Menos de 15 dias antes da data de chegada – sem reembolso.</p>",
+          "taxa_gateway_percentual": -0.08
+        },
+        {
+          "id": "pix_sinal",
+          "label": "Pix sinal 30% e 70% (valor total com 8% de desconto)",
+          "tipo": "pix_sinal",
+          "parcelas_maximas": 2,
+          "juros": false,
+          "descricao": "<h4>POLÍTICA DE CONFIRMAÇÃO E CANCELAMENTO</h4><p><b>Confirmação da Reserva:</b></p><p>O sinal corresponde a 30% do valor total da reserva, e deve ser pago no momento da reserva.<br>Enquanto o pagamento do sinal não for realizado, a hospedagem permanecerá disponível para outros interessados.<br>O saldo de 70% deverá ser pago até a data de saída.</p><p><b>Cancelamento:</b></p><p>Até 30 dias antes da data de chegada – reembolso de 100% do valor pago.<br>Até 15 dias antes da data de chegada – reembolso de 50% do valor pago.<br>Menos de 15 dias antes da data de chegada – sem reembolso.</p>",
+          "taxa_gateway_percentual": -0.08
+        }
+      ],
+      "regras_idade_precificacao": {
+        "hospedagem": [
+          {
+            "faixa_min_anos": 0,
+            "faixa_max_anos": 4,
+            "percentual_valor_adulto": 0.0,
+            "limite_gratuidade_por_reserva": 1,
+            "regra_excedente_gratuito": {
+              "percentual_valor_adulto": 0.5,
+              "descricao": "Crianças 0-4 anos extras pagam 50% da hospedagem"
+            }
+          },
+          {
+            "faixa_min_anos": 5,
+            "faixa_max_anos": 10,
+            "percentual_valor_adulto": 0.5,
+            "descricao": "Crianças de 5 a 10 anos pagam 50% do valor de hospedagem"
+          },
+          {
+            "faixa_min_anos": 11,
+            "percentual_valor_adulto": 1.0,
+            "descricao": "Acima de 10 anos pagam valor integral de hospedagem"
+          }
+        ],
+        "evento": []
+      },
+      "cupons_desconto": [
+        {
+          "codigo": "NEIDE10",
+          "tipo_desconto": "percentual",
+          "valor_desconto": 0.1,
+          "data_validade_fim": "2090-10-10T23:59:59",
+          "aplicacao": "hospedagem"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adiciona o evento **Imersão com Neide Rigo** ao formulário de reservas.

## O que foi feito
- **`G014`** em `eventos.json` — form único `hospedagem_apenas` (25 a 27/set/2026, 2 diárias) com 3 modalidades numa só tela, adotando o padrão de "sem pernoite" como tipo de acomodação (já usado em G008–G011), em vez de dois formulários separados.
- **Evento criado na tabela `events` do Supabase** (id `9299fde5-7407-4cca-8c70-82215b15cf0c`), replicando o padrão do Gomides (partner Fazenda Serrinha, event_type Hospedagem, segment Retiros, class "evento aberto", date 2026-09-01). Esse id é usado como `external_reference` → **vínculo Asaas** (padrão `hospedagem-event-id-fazenda-serrinha`).

## Valores (conferidos contra a landing)
| Modalidade | Base (6x) | PIX à vista −8% | Cartão à vista −4% |
|---|---|---|---|
| Quarto privativo | R$ 1.399 | R$ 1.287,08 | R$ 1.343,04 |
| Alojamento coletivo | R$ 1.158 | R$ 1.065,36 | R$ 1.111,68 |
| Sem pernoite (almoço + café) | R$ 883 | R$ 812,36 | R$ 847,68 |

- Cupom **NEIDE10** (10% sobre hospedagem).
- Crianças 5–10 anos: 50%; menores de 4: cortesia (1/reserva).
- Header com logo só da Serrinha.

## A confirmar
- **Planilha de reservas**: usei a mais recente em uso (a do G013/Alan Kaplan, `1IrTcq80...`). Se a imersão deve ter planilha própria, é só trocar.
- As **3 vagas de cota social** (seleção por carta) ficaram em `observacoes_adicionais`, por serem processo manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)