### PR TITLE
Migração Vercel + secret escopado (ian-memory#120)

### DIFF
--- a/js/webhookIntegration.js
+++ b/js/webhookIntegration.js
@@ -2,7 +2,7 @@
 class WebhookIntegration {
     constructor() {
         this.endpoints = {
-            submission: 'https://andremejitarian--pranna-webhook-server-fastapi-app.modal.run/api/webhooks/prod/fazenda-serrinha/fazenda-checkin-grupos?secret=6f0a9e372a658fede926e6b001a92b431b98bdc5c6034dbf274a076ac98949f1&sync=true'
+            submission: 'https://andremejitarian--pranna-webhook-server-fastapi-app.modal.run/api/webhooks/prod/fazenda-serrinha/fazenda-checkin-grupos?secret=bfd64938aaf7b7b6f411d6c2f3036643c9be243602490c81&sync=true'
         };
         this.timeout = 60000;
         this.retryAttempts = 1;


### PR DESCRIPTION
## O que muda

- **`js/webhookIntegration.js`**: troca o valor de `?secret=` na URL do webhook (Modal) do secret global exposto pelo **secret escopado deste site**. A URL do Modal (host + path `/api/webhooks/prod/...`) permanece idêntica; só o secret muda.
- Nenhuma outra alteração. Site 100% estático, sem `netlify.toml`, `_redirects`, Netlify Forms ou functions — **não precisa de `vercel.json`** (preset \"Other\", sem build, output na raiz).

## Contexto

Parte da migração Netlify→Vercel (Hobby) + rotação de secrets de webhook — andremejitarian/ian-memory#120. Produção atual deste form: `fazendaserrinha.netlify.app` (Netlify auto-deploy do main).

## ⚠️ NÃO MERGEAR

**NÃO MERGEAR antes do deploy do Modal com os secrets novos (PR do ian-automacoes).** O Modal precisa aceitar o secret escopado (fase de secrets duais) antes deste form apontar para ele, senão todo submit quebra. Sequência completa no runbook de cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)