### PR TITLE
DDI do select no payload do webhook (E.164, ian-memory#119 P3)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2277,6 +2277,11 @@ function prepareFormData(inscricaoId) {
         const participantForWebhook = {
             fullName: participantData.fullName,
             phone: participantData.phone,
+            // E.164 (ian-memory#119 P3): DDI do select agora entra no payload —
+            // antes era capturado em extractParticipantData e descartado aqui,
+            // deixando número estrangeiro ambíguo no pipeline (ian-automacoes).
+            phoneCountryCode: participantData.phoneCountryCode || '+55',
+            phoneCountry: participantData.phoneCountry || 'Brasil',
             cpf: participantData.cpf,
             cpfPessoal: participantData.cpfPessoal || undefined,
             gender: participantData.gender,
@@ -2338,7 +2343,9 @@ function prepareFormData(inscricaoId) {
         nome: responsiblePayer.fullName,
         cpf: responsiblePayer.cpf,
         email: responsiblePayer.email,
-        telefone: responsiblePayer.phone
+        telefone: responsiblePayer.phone,
+        // E.164 (ian-memory#119 P3): DDI do responsável no payload
+        phoneCountryCode: responsiblePayer.phoneCountryCode || '+55'
     };
 
     // NOVO: Adicionar endereço se disponível


### PR DESCRIPTION
## O quê

`extractParticipantData` (js/script.js) já capturava `phoneCountryCode`/`phoneCountry` do select de país, mas o objeto enviado ao webhook (`participantForWebhook` e `responsavelCompleto`) descartava os campos — número estrangeiro chegava ambíguo no pipeline, que assume `+55` (diagnóstico da auditoria de 06/07 em andremejitarian/ian-memory#119, item P3).

## Como

Aditivo: `phoneCountryCode` (default `'+55'`) e `phoneCountry` (default `'Brasil'`) agora acompanham `phone` em cada participante, e `phoneCountryCode` no `responsavelCompleto`. Nenhum campo existente muda de forma — consumidores atuais seguem funcionando.

## Consumo

O lado consumidor (ian-automacoes: `checkin-grupos.ts` / `acampamento-inscricao.ts`) passa a respeitar `phoneCountryCode` via `toE164BR()` no PR de resíduos da #119.

## Deploy necessário

Site estático — merge + publish do host (Netlify/_redirects presente). Sem migração.

Refs: andremejitarian/ian-memory#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)